### PR TITLE
bugs in lstm and batchnorm layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Keras has a neat API to view the visualization of the model which is very helpfu
 
 ### Usage
 
-- `pip install torchsummary` or 
 - `git clone https://github.com/Bond-SYSU/pytorch-summary`
 
 ```python

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Keras has a neat API to view the visualization of the model which is very helpfu
 ### Usage
 
 - `pip install torchsummary` or 
-- `git clone https://github.com/sksq96/pytorch-summary`
+- `git clone https://github.com/Bond-SYSU/pytorch-summary`
 
 ```python
 from torchsummary import summary

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup, find_packages
 
 setup(
-	name='torchsummary',
-	version='1.1',
-	description='Model summary in PyTorch similar to `model.summary()` in Keras',
-	url='https://github.com/sksq96/pytorch-summary',
-	author='Shubham Chandel @sksq96',
-	author_email='shubham.zeez@gmail.com',
+	name='dubugsummary',
+	version='0.1',
+	description='Model debug and summary in PyTorch',
+	url='https://github.com/Bond-SYSU/pytorch-summary',
+	author='Shubham Chandel @',
+	author_email='huangdb3@mail2.sysu.edu.cn',
 	packages=['torchsummary'],
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
 	version='0.1',
 	description='Model debug and summary in PyTorch',
 	url='https://github.com/Bond-SYSU/pytorch-summary',
-	author='Shubham Chandel @',
+	author='Bond @Bond-SYSU',
 	author_email='huangdb3@mail2.sysu.edu.cn',
 	packages=['torchsummary'],
 )


### PR DESCRIPTION
the original version can't work in LSTM layer, since its output is tuple of tuple, for example, "(output, (h_n, c_n))",  when running the original code in a model with lstm layer, it will get an error, so I change the method to get the shape of layer's output

what's  more, the original version can't get the parameters' information of RNN layers, since its parameters' name have  special postfix, like "weight_ih_l, bias_ih_l", not just "weight, bias", so i use a more general method to get the parameters' information

last but not least, I find that, in some layer like batchnorm request batch_size bigger than, otherwise, it will get errors, so i change the batch_size to 2

Co-Authored-By: bond-sysu <bond-sysu@users.noreply.github.com>