### PR TITLE
Added 'device' argument

### DIFF
--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -5,7 +5,7 @@ from torch.autograd import Variable
 from collections import OrderedDict
 
 
-def summary(model, input_size):
+def summary(model, input_size, device="cuda"):
         def register_hook(module):
             def hook(module, input, output):
                 class_name = str(module.__class__).split('.')[-1].split("'")[0]
@@ -34,7 +34,10 @@ def summary(model, input_size):
                not (module == model)):
                 hooks.append(module.register_forward_hook(hook))
                 
-        if torch.cuda.is_available():
+        device = device.lower()
+        assert device in ["cuda", "cpu"], "Input device is not valid, please specify 'cuda' or 'cpu'"
+
+        if device is "cuda" and torch.cuda.is_available():
             dtype = torch.cuda.FloatTensor
         else:
             dtype = torch.FloatTensor


### PR DESCRIPTION
Added a 'device' parameter to the summary method. It defaults to 'cuda' so as to not affect existing applications, but will allow 'cpu' to be specified and used even if a GPU exists. It follows the new PyTorch to(device) standard where device='cuda' is for GPU and device='cpu' is for CPU.
