### PR TITLE
Use torch.device for storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ class Net(nn.Module):
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu") # PyTorch v0.4.0
 model = Net().to(device)
 
-summary(model, (1, 28, 28))
+summary(model, (1, 28, 28), device=device)
 ```
 
 

--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -41,19 +41,11 @@ def summary(model, *input_size, batch_size=-1, device="cuda"):
         ):
             hooks.append(module.register_forward_hook(hook))
 
-    device = device.lower()
-    assert device in [
-        "cuda",
-        "cpu",
-    ], "Input device is not valid, please specify 'cuda' or 'cpu'"
-
-    if device == "cuda" and torch.cuda.is_available():
-        dtype = torch.cuda.FloatTensor
-    else:
-        dtype = torch.FloatTensor
+    if isinstance(device, str):
+       device = torch.device(device.lower())
 
     # multiple inputs to the network
-    x = [torch.rand(2, *in_size).type(dtype) for in_size in input_size]
+    x = [torch.rand(2, *in_size).to(device) for in_size in input_size]
     # print(type(x[0]))
 
     # create properties


### PR DESCRIPTION
PyTorch >v4.0 defines device object for Tensor storage that allow users to specify a CPU or a GPU device to operate on. Before this commit, the device argument of the summary() function expected a string that only changed the Tensor type between torch.FloatTensor or torch.cuda.FloatTensor. 

The optional device= kwarg now expects a torch.device. If it finds a string, it tries to convert it to a torch.device object. By using the .to() Tensor method, it sends the Tensor to the right storage, so that summary() does not fail when using a GPU that is not the default one.

Note: by default, we could assume that all parameters of the model are on the same device and infer the right one from the model, however this might not be always the case.