### PR TITLE
Fixing input size computation to work with multiple inputs

### DIFF
--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -97,7 +97,7 @@ def summary(model, input_size, batch_size=-1, device="cuda"):
         print(line_new)
 
     # assume 4 bytes/number (float on cuda).
-    total_input_size = abs(np.prod(input_size) * batch_size * 4. / (1024 ** 2.))
+    total_input_size = abs(np.sum([np.prod(in_tuple) for in_tuple in input_size]) * batch_size * 4. / (1024 ** 2.))
     total_output_size = abs(2. * total_output * 4. / (1024 ** 2.))  # x2 for gradients
     total_params_size = abs(total_params.numpy() * 4. / (1024 ** 2.))
     total_size = total_params_size + total_output_size + total_input_size


### PR DESCRIPTION
Currently if there are multiple input tuples in `input_size`, the function errors on the line I modified, as it attempts to multiply a number by a tuple: 
```
<ipython-input-18-d57df7dd93f4> in <module>()
      3                 conv_output_size=1536)
      4 summary_model.cuda()
----> 5 summary(summary_model, [(3, 128, 128), (21,)])

/usr/local/lib/python3.6/dist-packages/torchsummary/torchsummary.py in summary(model, input_size, batch_size, device)
     98 
     99     # assume 4 bytes/number (float on cuda).
--> 100     total_input_size = abs(np.prod(input_size) * batch_size * 4. / (1024 ** 2.))
    101     total_output_size = abs(2. * total_output * 4. / (1024 ** 2.))  # x2 for gradients
    102     total_params_size = abs(total_params.numpy() * 4. / (1024 ** 2.))

/usr/local/lib/python3.6/dist-packages/numpy/core/fromnumeric.py in prod(a, axis, dtype, out, keepdims)
   2564 
   2565     return _methods._prod(a, axis=axis, dtype=dtype,
-> 2566                           out=out, **kwargs)
   2567 
   2568 

/usr/local/lib/python3.6/dist-packages/numpy/core/_methods.py in _prod(a, axis, dtype, out, keepdims)
     33 
     34 def _prod(a, axis=None, dtype=None, out=None, keepdims=False):
---> 35     return umr_prod(a, axis, dtype, out, keepdims)
     36 
     37 def _any(a, axis=None, dtype=None, out=None, keepdims=False):

TypeError: can't multiply sequence by non-int of type 'tuple'
```

The solution is simple. Conceptually, we want to some input sizes across different inputs, taking the product within each input. I implemented it using a list comprehension for the products and a sum outside. 