### PR TITLE
support zero-dim input_size: summary(model, [(3, 64, 64), tuple()])

### DIFF
--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -97,6 +97,7 @@ def summary(model, input_size, batch_size=-1, device="cuda"):
         print(line_new)
 
     # assume 4 bytes/number (float on cuda).
+    input_size = [s for s in input_size if len(s) > 0]
     total_input_size = abs(np.prod(input_size) * batch_size * 4. / (1024 ** 2.))
     total_output_size = abs(2. * total_output * 4. / (1024 ** 2.))  # x2 for gradients
     total_params_size = abs(total_params.numpy() * 4. / (1024 ** 2.))


### PR DESCRIPTION
For conditional GAN models, labels are usually zero-dim.
e.g.) [cgans with projection discriminator](https://github.com/crcrpar/pytorch.sngan_projection)

Since `np.prod()` breaks if there is empty tuple in the list, empty entries should be removed in advance.