### PR TITLE
Multi-gpu compatibility: torch-summary for 'cuda:1' and so on

### DIFF
--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -41,75 +41,83 @@ def summary(model, input_size, batch_size=-1, device="cuda"):
         ):
             hooks.append(module.register_forward_hook(hook))
 
-    device = device.lower()
-    assert device in [
-        "cuda",
-        "cpu",
-    ], "Input device is not valid, please specify 'cuda' or 'cpu'"
-
-    if device == "cuda" and torch.cuda.is_available():
-        dtype = torch.cuda.FloatTensor
-    else:
-        dtype = torch.FloatTensor
+    if(isinstance(device, str)):
+      device.lower()
+    # torch parse function that returns an object of type: torch.device. argument can be passed as a torch.device object, a string('cuda:1') or integer device index(1)
+    device=torch._C._nn._parse_to(device)[0]
 
     # multiple inputs to the network
     if isinstance(input_size, tuple):
         input_size = [input_size]
 
     # batch_size of 2 for batchnorm
-    x = [torch.rand(2, *in_size).type(dtype) for in_size in input_size]
-    # print(type(x[0]))
+    try:
+        if (device == torch.device('cuda')):
+            if(torch.cuda.is_available()):
+                x = [torch.rand(2, *in_size).to('cuda') for in_size in input_size]
+            else:
+                raise Exception("No CUDA-capable device detected.")
+        elif not (device == torch.device('cpu') or device == torch.device('cpu:0')):
+            with torch.cuda.device(device):
+                if(torch.cuda.is_available()):
+                    x = [torch.rand(2, *in_size).to(device) for in_size in input_size]
+    except RuntimeError:
+        raise Exception("Specified device either doesn't exist or is not CUDA-capable. ") from None
+    else:
+        if (device == torch.device('cpu') or device == torch.device('cpu:0')):
+            x = [torch.rand(2, *in_size).to('cpu') for in_size in input_size]
+        # print(type(x[0]))
 
-    # create properties
-    summary = OrderedDict()
-    hooks = []
+        # create properties
+        summary = OrderedDict()
+        hooks = []
 
-    # register hook
-    model.apply(register_hook)
+        # register hook
+        model.apply(register_hook)
 
-    # make a forward pass
-    # print(x.shape)
-    model(*x)
+        # make a forward pass
+        # print(x.shape)
+        model(*x)
 
-    # remove these hooks
-    for h in hooks:
-        h.remove()
+        # remove these hooks
+        for h in hooks:
+            h.remove()
 
-    print("----------------------------------------------------------------")
-    line_new = "{:>20}  {:>25} {:>15}".format("Layer (type)", "Output Shape", "Param #")
-    print(line_new)
-    print("================================================================")
-    total_params = 0
-    total_output = 0
-    trainable_params = 0
-    for layer in summary:
-        # input_shape, output_shape, trainable, nb_params
-        line_new = "{:>20}  {:>25} {:>15}".format(
-            layer,
-            str(summary[layer]["output_shape"]),
-            "{0:,}".format(summary[layer]["nb_params"]),
-        )
-        total_params += summary[layer]["nb_params"]
-        total_output += np.prod(summary[layer]["output_shape"])
-        if "trainable" in summary[layer]:
-            if summary[layer]["trainable"] == True:
-                trainable_params += summary[layer]["nb_params"]
+        print("----------------------------------------------------------------")
+        line_new = "{:>20}  {:>25} {:>15}".format("Layer (type)", "Output Shape", "Param #")
         print(line_new)
+        print("================================================================")
+        total_params = 0
+        total_output = 0
+        trainable_params = 0
+        for layer in summary:
+            # input_shape, output_shape, trainable, nb_params
+            line_new = "{:>20}  {:>25} {:>15}".format(
+                layer,
+                str(summary[layer]["output_shape"]),
+                "{0:,}".format(summary[layer]["nb_params"]),
+            )
+            total_params += summary[layer]["nb_params"]
+            total_output += np.prod(summary[layer]["output_shape"])
+            if "trainable" in summary[layer]:
+                if summary[layer]["trainable"] == True:
+                    trainable_params += summary[layer]["nb_params"]
+            print(line_new)
 
-    # assume 4 bytes/number (float on cuda).
-    total_input_size = abs(np.prod(input_size) * batch_size * 4. / (1024 ** 2.))
-    total_output_size = abs(2. * total_output * 4. / (1024 ** 2.))  # x2 for gradients
-    total_params_size = abs(total_params.numpy() * 4. / (1024 ** 2.))
-    total_size = total_params_size + total_output_size + total_input_size
+      # assume 4 bytes/number (float on cuda).
+        total_input_size = abs(np.prod(input_size) * batch_size * 4. / (1024 ** 2.))
+        total_output_size = abs(2. * total_output * 4. / (1024 ** 2.))  # x2 for gradients
+        total_params_size = abs(total_params.numpy() * 4. / (1024 ** 2.))
+        total_size = total_params_size + total_output_size + total_input_size
 
-    print("================================================================")
-    print("Total params: {0:,}".format(total_params))
-    print("Trainable params: {0:,}".format(trainable_params))
-    print("Non-trainable params: {0:,}".format(total_params - trainable_params))
-    print("----------------------------------------------------------------")
-    print("Input size (MB): %0.2f" % total_input_size)
-    print("Forward/backward pass size (MB): %0.2f" % total_output_size)
-    print("Params size (MB): %0.2f" % total_params_size)
-    print("Estimated Total Size (MB): %0.2f" % total_size)
-    print("----------------------------------------------------------------")
-    # return summary
+        print("================================================================")
+        print("Total params: {0:,}".format(total_params))
+        print("Trainable params: {0:,}".format(trainable_params))
+        print("Non-trainable params: {0:,}".format(total_params - trainable_params))
+        print("----------------------------------------------------------------")
+        print("Input size (MB): %0.2f" % total_input_size)
+        print("Forward/backward pass size (MB): %0.2f" % total_output_size)
+        print("Params size (MB): %0.2f" % total_params_size)
+        print("Estimated Total Size (MB): %0.2f" % total_size)
+        print("----------------------------------------------------------------")
+        # return summary

--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -104,7 +104,7 @@ def summary(model, input_size, batch_size=-1, device="cuda"):
                     trainable_params += summary[layer]["nb_params"]
             print(line_new)
 
-      # assume 4 bytes/number (float on cuda).
+        # assume 4 bytes/number (float on cuda).
         total_input_size = abs(np.prod(input_size) * batch_size * 4. / (1024 ** 2.))
         total_output_size = abs(2. * total_output * 4. / (1024 ** 2.))  # x2 for gradients
         total_params_size = abs(total_params.numpy() * 4. / (1024 ** 2.))


### PR DESCRIPTION
Models in GPU devices other than 'cuda:0' can be summarized after this edit. 

An edit was made in the way the kwarg 'device' accepted values. Instead of only accepting string values, the current edit allows for torch.device objects and (legacy) integer values to be accepted.
`summary(model, (1,28,28),device="cuda:2"`
`summary(model, (1,28,28),device=torch.device("cuda")`
