### PR TITLE
fix: Fixed hook for DenseNet

### DIFF
--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -48,6 +48,7 @@ def summary_string(model, input_size, batch_size=-1, device=torch.device('cuda:0
         if (
             not isinstance(module, nn.Sequential)
             and not isinstance(module, nn.ModuleList)
+            and not any(module.children())
         ):
             hooks.append(module.register_forward_hook(hook))
 

--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -45,11 +45,7 @@ def summary_string(model, input_size, batch_size=-1, device=torch.device('cuda:0
                 params += torch.prod(torch.LongTensor(list(module.bias.size())))
             summary[m_key]["nb_params"] = params
 
-        if (
-            not isinstance(module, nn.Sequential)
-            and not isinstance(module, nn.ModuleList)
-            and not any(module.children())
-        ):
+        if not any(module.children()):
             hooks.append(module.register_forward_hook(hook))
 
     # multiple inputs to the network


### PR DESCRIPTION
Hello there,

I found recently that the main function does not work on the `torchvision` implementation of DenseNet.
```
from torchvision.models import densenet121
from torchsummary import summary
model = densenet121().eval().cuda()
summary(model, (3, 224, 224))
```
would yield
```
~/Documents/pytorch-summary/torchsummary/torchsummary.py in hook(module, input, output)
     36             m_key = "%s-%i" % (class_name, module_idx + 1)
     37             summary[m_key] = OrderedDict()
---> 38             summary[m_key]["input_shape"] = list(input[0].size())
     39             summary[m_key]["input_shape"][0] = batch_size
     40             if isinstance(output, (list, tuple)):

AttributeError: 'list' object has no attribute 'size'
```
The reason behind this is the `_DenseLayer` type in the architecture. Since it does not inherit from `torch.nn.Sequential` or `torch.nn.ModuleList`, the element is not skipped when hooking all object children.

This PR fixes it by checking if the current child has any children modules, before registering ahook.

Hope this helps!
Cheers