### PR TITLE
feat: Default device is set to model device

### DIFF
--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -6,15 +6,19 @@ from collections import OrderedDict
 import numpy as np
 
 
-def summary(model, input_size, batch_size=-1, device=torch.device('cuda:0'), dtypes=None):
+def summary(model, input_size, batch_size=-1, dtypes=None):
     result, params_info = summary_string(
-        model, input_size, batch_size, device, dtypes)
+        model, input_size, batch_size, dtypes)
     print(result)
 
     return params_info
 
 
-def summary_string(model, input_size, batch_size=-1, device=torch.device('cuda:0'), dtypes=None):
+def summary_string(model, input_size, batch_size=-1, dtypes=None):
+
+    # Take the device of the first model parameter
+    device = next(model.parameters()).device
+
     if dtypes == None:
         dtypes = [torch.FloatTensor]*len(input_size)
 


### PR DESCRIPTION
Avoids specifying device since the input tensor needs to be on the same on as the model. This is useful in multi-GPUs environment or to freely use the function on CPU.

Previously
```
from torchvision.models import resnet18
from torchsummary import summary
model = resnet18().eval()
summary(model, (3, 224, 224))
```
would fairly yield
```
RuntimeError: Input type (torch.cuda.FloatTensor) and weight type (torch.FloatTensor) should be the same
```

The device is now dynamically set to the model device.

Any feedback is welcome, cheers!