### PR TITLE
Hello !! I modify the method of counting parameters

### DIFF
--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -38,11 +38,11 @@ def summary_string(model, input_size, batch_size=-1, device=torch.device('cuda:0
                 summary[m_key]["output_shape"][0] = batch_size
 
             params = 0
-            if hasattr(module, "weight") and hasattr(module.weight, "size"):
-                params += torch.prod(torch.LongTensor(list(module.weight.size())))
-                summary[m_key]["trainable"] = module.weight.requires_grad
-            if hasattr(module, "bias") and hasattr(module.bias, "size"):
-                params += torch.prod(torch.LongTensor(list(module.bias.size())))
+
+            for p in module.parameters(recurse=False):
+                param = torch.tensor(p.size()).prod()
+                summary[m_key]["trainable"] = p.requires_grad
+                params += param
             summary[m_key]["nb_params"] = params
 
         if (


### PR DESCRIPTION
Hi everyone.
I found that the origin code only considers the parameters named "weight" and "bias".
When we want to make some custom modules, like : 

```
class NoiseLinear(nn.Module):
    def __init__(self,inf,outf):
        super(NoiseLinear,self).__init__()
        self.w_mu = nn.Parameter(torch.Tensor(outf,inf))
        self.w_sig = nn.Parameter(torch.Tensor(outf,inf))
        self.b_mu = nn.Parameter(torch.Tensor(outf))
        self.b_sig = nn.Parameter(torch.Tensor(outf))

        # no parameters named "weight" and "bias" here
```
The original counting method will count 0 parameters.
So I modify the code to count based on parameters() iterator.
It looks good to me after using for a while.



