### PR TITLE
Fix parameter count

### DIFF
--- a/torchsummary/tests/test_models/test_model.py
+++ b/torchsummary/tests/test_models/test_model.py
@@ -1,6 +1,8 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.nn.parameter import Parameter
+
 
 class SingleInputNet(nn.Module):
     def __init__(self):
@@ -19,6 +21,7 @@ class SingleInputNet(nn.Module):
         x = self.fc2(x)
         return F.log_softmax(x, dim=1)
 
+
 class MultipleInputNet(nn.Module):
     def __init__(self):
         super(MultipleInputNet, self).__init__()
@@ -35,6 +38,7 @@ class MultipleInputNet(nn.Module):
         x2 = self.fc2b(x2)
         x = torch.cat((x1, x2), 0)
         return F.log_softmax(x, dim=1)
+
 
 class MultipleInputNetDifferentDtypes(nn.Module):
     def __init__(self):
@@ -54,3 +58,45 @@ class MultipleInputNetDifferentDtypes(nn.Module):
         # set x2 to FloatTensor
         x = torch.cat((x1, x2), 0)
         return F.log_softmax(x, dim=1)
+
+
+class NestedNet(nn.Module):
+    def __init__(self):
+        super(NestedNet, self).__init__()
+        self.conv_block1 = ConvBlock(1, 10, 5)
+        self.conv_block2 = ConvBlock(10, 20, 5)
+        self.conv_drop = nn.Dropout2d(0.3)
+        self.fc1 = nn.Linear(320, 50)
+        self.fc2 = nn.Linear(50, 10)
+
+    def forward(self, x):
+        x = F.relu(self.conv_block1(x))
+        x = F.relu((self.conv_drop(self.conv_block2(x))))
+        x = x.view(-1, 320)
+        x = F.relu(self.fc1(x))
+        x = self.fc2(x)
+        return F.log_softmax(x, dim=1)
+
+
+class ConvBlock(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size):
+        super(ConvBlock, self).__init__()
+        self.conv = nn.Conv2d(in_channels, out_channels, kernel_size)
+        self.bn = nn.BatchNorm2d(out_channels)
+        self.pool = nn.MaxPool2d(2, stride=2)
+
+    def forward(self, x):
+        x = F.relu(self.conv(x))
+        x = self.bn(x)
+        x = self.pool(x)
+        return x
+
+
+class CustomModule(nn.Module):
+    def __init__(self):
+        super(CustomModule, self).__init__()
+        weight_tensor = torch.rand(50, 50)
+        self.W = Parameter(weight_tensor, requires_grad=True)
+
+    def forward(self, x):
+        return torch.einsum("bij,jk->bik", x, self.W)

--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -37,13 +37,14 @@ def summary_string(model, input_size, batch_size=-1, device=torch.device('cuda:0
                 summary[m_key]["output_shape"] = list(output.size())
                 summary[m_key]["output_shape"][0] = batch_size
 
-            params = 0
-            if hasattr(module, "weight") and hasattr(module.weight, "size"):
-                params += torch.prod(torch.LongTensor(list(module.weight.size())))
-                summary[m_key]["trainable"] = module.weight.requires_grad
-            if hasattr(module, "bias") and hasattr(module.bias, "size"):
-                params += torch.prod(torch.LongTensor(list(module.bias.size())))
-            summary[m_key]["nb_params"] = params
+            nb_params = 0
+            trainable_params = 0
+            for name, p in module.named_parameters():
+                params = torch.numel(p)
+                nb_params += params
+                trainable_params += params if p.requires_grad else 0
+            summary[m_key]["nb_params"] = nb_params
+            summary[m_key]["trainable"] = trainable_params
 
         if (
             not isinstance(module, nn.Sequential)
@@ -89,12 +90,11 @@ def summary_string(model, input_size, batch_size=-1, device=torch.device('cuda:0
             str(summary[layer]["output_shape"]),
             "{0:,}".format(summary[layer]["nb_params"]),
         )
-        total_params += summary[layer]["nb_params"]
+        total_params = summary[layer]["nb_params"]
 
         total_output += np.prod(summary[layer]["output_shape"])
         if "trainable" in summary[layer]:
-            if summary[layer]["trainable"] == True:
-                trainable_params += summary[layer]["nb_params"]
+            trainable_params = summary[layer]["trainable"]
         summary_str += line_new + "\n"
 
     # assume 4 bytes/number (float on cuda).


### PR DESCRIPTION
This contribution introduces three mayor changes:

1. Parameters are now counted using the `parameters()` function of `nn.Module` and the `numel()` function of the `nn.parameters.Parameter`. This allows for counting the weights of custom modules with other keywords than just `weight` or `bias`. The fix addresses issues [#95](https://github.com/sksq96/pytorch-summary/issues/95) and [#65](https://github.com/sksq96/pytorch-summary/issues/65) .
2. Trainable parameters are now counted on a separate accumulator using the `requires_grad` attribute of parameters.
3. The API is expanded by adding a parameter `recurse` both to `summary()` and `summary_string()`, which is `True` by default.
If set, the summary string will only be built for direct children of the model (and the model module itself).