### PR TITLE
Fix handling input_size with multi-input

### DIFF
--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -98,7 +98,9 @@ def summary_string(model, input_size, batch_size=-1, device=torch.device('cuda:0
         summary_str += line_new + "\n"
 
     # assume 4 bytes/number (float on cuda).
-    total_input_size = abs(np.prod(sum(input_size, ()))
+    # to handle the case of multi-input: prod(input1) + prod(input2) + ...
+    n_input_size = np.array([np.prod(i) for i in input_size]).sum() if isinstance(input_size, list) else np.prod(input_size)
+    total_input_size = abs(n_input_size
                            * batch_size * 4. / (1024 ** 2.))
     total_output_size = abs(2. * total_output * 4. /
                             (1024 ** 2.))  # x2 for gradients


### PR DESCRIPTION
While dealing with multi-input, the current implementation calculates the number of elements in input as the product of all dimensions in all inputs, I believe this is not accurate.
For example, if we have input1 with dimensions [1,5,5] and input2 with dimensions [1,10,10]:
Current implementation: number of elements = 1 * 5 * 5 * 1 * 10 * 10 = 2500 elements
Where it should be: number of elements = (1 * 5 * 5) + (1 * 10 * 10) = 125 elements
As they are two separate inputs.