### PR TITLE
Added OrderedDict as an output datatype

### DIFF
--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -33,6 +33,14 @@ def summary_string(model, input_size, batch_size=-1, device=torch.device('cuda:0
                 summary[m_key]["output_shape"] = [
                     [-1] + list(o.size())[1:] for o in output
                 ]
+            elif isinstance(output,OrderedDict):
+                keys = list(output.keys())
+                if 'out' in keys:
+                    key='out'
+                else:
+                    key = keys[-1]
+                summary[m_key]["output_shape"] = list(output[key].size())
+                summary[m_key]["output_shape"][0] = batch_size    
             else:
                 summary[m_key]["output_shape"] = list(output.size())
                 summary[m_key]["output_shape"][0] = batch_size


### PR DESCRIPTION
Some pre-trained models like the [deeplabv3_resnet50](https://pytorch.org/hub/pytorch_vision_deeplabv3_resnet101/) returns an `OrderedDict` containing the semantic mask and the auxillary loss as two separate Tensors under the keys `'out'` and `'aux'`.

Usage of torchsummary with such models was not compatible since `OrderedDict` had not been considered as a potential output type. 

Error thrown:  `'collections.OrderedDict' object has no attribute 'size'`

This issue has now been fixed.