### PR TITLE
Add license to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(
     author="Shubham Chandel @sksq96",
     author_email="shubham.zeez@gmail.com",
     packages=["torchsummary"],
-    license="MIT"
+    license="MIT",
 )

--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,5 @@ setup(
     author="Shubham Chandel @sksq96",
     author_email="shubham.zeez@gmail.com",
     packages=["torchsummary"],
+    license="MIT"
 )


### PR DESCRIPTION
For automatic license checkers, it would be helpful if "MIT" is specified in the `setup.py`.